### PR TITLE
Refactor ALL the views

### DIFF
--- a/lists/forms.py
+++ b/lists/forms.py
@@ -32,7 +32,11 @@ class ListItemForm(forms.ModelForm):
         if commit:
             instance.save()
             self.save_m2m()
-        instance.list.add(List.objects.get(pk=self.cleaned_data.get('list_pk')))
+        print(f"{self.cleaned_data.get('list_pk')} listpk")
+        if self.cleaned_data.get('list_pk'):
+            instance.list.add(List.objects.get(pk=self.cleaned_data.get('list_pk')))
+        elif instance.parent:
+            instance.list.add(instance.parent.list.first()) #TODO: Use another field (ListItem.originating_list would be a good name) instead
         return instance
 
 class DetailedListItemForm(forms.ModelForm):

--- a/lists/forms.py
+++ b/lists/forms.py
@@ -54,6 +54,12 @@ class DetailedListItemForm(forms.ModelForm):
         }
 
 class ListForm(forms.ModelForm):
+    #parent_pk = forms.IntegerField(required=False)
     class Meta:
         model = List
-        fields = ('title',)
+        fields = (
+            'title',
+            'owner',
+            'parent',
+        )
+

--- a/lists/static/lists/lists.css
+++ b/lists/static/lists/lists.css
@@ -190,15 +190,15 @@ button {
     background: #e3e3e3;
 }
 
-.li-buttons-right > button {
+.li-buttons-right button {
     margin-left: 10px;
 }
 
-.li-buttons-right > button > svg.red {
+.li-buttons-right button > svg.red {
     color: #c50000;
 }
 
-.li-buttons-right > button > svg {
+.li-buttons-right button > svg {
     color: gray;
     height: 1.5em;
     vertical-align: middle;

--- a/lists/templates/lists/item-edit.html
+++ b/lists/templates/lists/item-edit.html
@@ -10,7 +10,7 @@
                 {% icon "corner-down-left" %}
             </label>
             <input type="hidden" name="parent_pk" _="on load set my @value to @data-item-pk of closest parent <li/>">
-            <input type="hidden" name="list_pk" _="on load set my @value to @data-list-pk of #listdisplay">
+            <input type="hidden" name="list_pk" _="on load set my @value to @data-list-pk of closest #new-item-button-container">
             {{ form.errors }}
         </form>
     </div>

--- a/lists/templates/lists/list-display.html
+++ b/lists/templates/lists/list-display.html
@@ -19,7 +19,9 @@
     {% endif %}
 </ul>
 {% if current_list %}
-    <button class="new-item-button" id="newitem" hx-trigger="click" hx-get="{% url 'item-edit' %}" hx-select="#newitem" hx-swap="outerHTML">
-        {% icon "plus" %}
-    </button>
+    <div class="new-item-button" id="new-item-button-container" data-list-pk="{{ current_list.pk }}">
+        <button class="new-item-button" id="newitem" hx-trigger="click" hx-get="{% url 'item-edit' %}" hx-select="#newitem" hx-swap="outerHTML">
+            {% icon "plus" %}
+        </button>
+    </div>
 {% endif %}

--- a/lists/templates/lists/list-edit.html
+++ b/lists/templates/lists/list-edit.html
@@ -1,10 +1,15 @@
-<div class="list-item edit" id="newitem">
-    <form method="post" action="{% url "new-list" parent_list_pk %}">{% csrf_token %}
-        title:{{ form.title }}<br>
-        {{ form.errors }}
-        <input type="submit" class="submit-button">
-    </form>
+{% load icon %}
+<div class="list-item">
+    <h2>New List</h2>
+    <div class="list-form-container">
+        <form method="post" action="{% url "list-edit" list_pk %}">{% csrf_token %}
+            <input type="hidden" name="parent" _="on load set my @value to @data-list-pk of closest parent <li/>">
+            <input type="hidden" name="owner" value="{{ request.user.pk }}">
+            {{ form.title }}
+            <label>
+                <input type="submit" value="Submit" hidden>
+                {% icon "corner-down-left" %}
+            </label>
+        </form>
+    </div>
 </div>
-
-<!--this file saved for future use, will be displayed in the lidt info div (not there yet) at the top of list-display.
-Using new-list.html for now, as the two are truly different enough to merit separate views.

--- a/lists/templates/lists/list-item.html
+++ b/lists/templates/lists/list-item.html
@@ -8,7 +8,12 @@
                 <button hx-trigger="click" hx-get="{% url 'item-edit' %}" hx-select=".new-item-form-container" hx-swap="outerHTML">New sub-item</button>
                 <div class="li-buttons-right">
                     {% for list in quick_access %}
-                    {% quick_access_list_button request=request list=list item=item current_list=list.pk %}
+                        {% if list in item.list.filter %}
+                            {% include 'lists/quick-access-list-button.html' with enabled=False current_list=current_list.pk list=list item=item %}
+                        {% else %}
+                            {% include 'lists/quick-access-list-button.html' with enabled=True current_list=current_list.pk list=list item=item %}
+                        {% endif %}
+{#                    {% quick_access_list_button request=request list=list item=item current_list=list.pk %}#}
                 {% endfor %}
                 </div>
             </div>

--- a/lists/templates/lists/list-selection-display.html
+++ b/lists/templates/lists/list-selection-display.html
@@ -1,11 +1,11 @@
 {% load lists_extras %}
-<li class="list-item">
+<li class="list-item" id="list-selection-display-{{ list.pk }}" data-list-pk="{{ list.pk }}">
     <div class="li-internal">
         <div class="li-left">
             <a href="{% url 'list' list.pk %}">
                 <h2>{{ list.title }}</h2>
             </a>
-            <button value="New Sublist" hx-trigger="click" hx-get="{% url "new-sublist" list.pk %}" hx-select="form"  hx-target="this" hx-swap="outerHTML">
+            <button value="New Sublist" hx-trigger="click" hx-get="{% url "list-edit" %}" hx-select="form"  hx-target="this" hx-swap="outerHTML">
                 New Sublist
             </button>
         </div>

--- a/lists/templates/lists/list-sidebar.html
+++ b/lists/templates/lists/list-sidebar.html
@@ -11,7 +11,7 @@
             {% list_selection_display list current_list request %}
         {% endif %}
     {% endfor %}
-    <button class="list-item add-button" value="New Sublist" hx-trigger="click" hx-get="{% url "new-list" %}" hx-swap="outerHTML">
+    <button class="list-item add-button" value="New Sublist" hx-trigger="click" hx-get="{% url "list-edit" %}" hx-swap="outerHTML">
         {% icon "plus" %}
     </button>
 </ul>

--- a/lists/templates/lists/quick-access-list-button.html
+++ b/lists/templates/lists/quick-access-list-button.html
@@ -1,11 +1,15 @@
 <!--Display a quick-access button to add a given item to another list-->
 {% load icon %}
-{% if enabled %}
-    <button id="addbutton" hx-trigger="click" hx-get="{% url "add-item-to-list" item=item.pk list=list.pk current_list=current_list %}" hx-swap="outerHTML">
-        {% icon "plus-circle" %} "{{ list.short_title }}"
+<form>
+    <input type="hidden" name="item_pk" _="on load set my @value to @data-item-pk of closest parent <li/>">
+    <input type="hidden" name="current_list_pk" _="on load set my @value to @data-list-pk of #listdisplay">
+    <input type="hidden" name="list_pk" value="{{ list.pk }}">
+    <button hx-trigger="click" hx-post="{% url 'toggle-list-on-item' %}" hx-swap="outerHTML" hx-select="button">
+        {% if enabled %}
+            {% icon "plus-circle" %}
+        {% else %}
+            {% icon "x-circle" class="red" %}
+        {% endif %}
+        {{ list.short_title }}
     </button>
-{% else %}
-    <button id="addbutton" hx-trigger="click" hx-get="{% url "remove-item-from-list" current_list=current_list item=item.pk list=list.pk %}" hx-swap="outerHTML">
-        {% icon "x-circle" class="red" %} "{{ list.short_title }}"
-    </button>
-{% endif %}
+</form>

--- a/lists/templatetags/lists_extras.py
+++ b/lists/templatetags/lists_extras.py
@@ -34,20 +34,6 @@ def get_list_tree(list):
         list = list.parent
     return list_tree
 
-@register.inclusion_tag('lists/quick-access-list-button.html')
-def quick_access_list_button(request, item, list, current_list=None):
-    #item = ListItem.objects.get(item)
-    #list = List.objects.get(list)
-    if list in item.list.filter():
-        enabled = False
-    else:
-        enabled = True
-    return ({
-        'item': item,
-        'list': list,
-        'enabled': enabled,
-        'current_list': current_list,
-    })
 
 @register.inclusion_tag('lists/star.html')
 def star(request, list):

--- a/lists/test_tasks.py
+++ b/lists/test_tasks.py
@@ -28,7 +28,7 @@ class AutoUncheckCase(TestCase):
         recurring_with_due_date = ListItem.objects.get(name='recurring_with_due_date')
         recurring_without_due_date = ListItem.objects.get(name='recurring_without_due_date')
         self.assertEqual(timezone.now().date() + datetime.timedelta(days=recurring_with_due_date.due_again_in),
-                         recurring_with_due_date.due_date.date())
+                         recurring_with_due_date.due_date)
         self.assertEqual(None, recurring_without_due_date.due_date)
         self.assertFalse(recurring_with_due_date.completed)
         self.assertFalse(recurring_without_due_date.completed)

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -3,6 +3,8 @@ from django.test import Client
 from django.shortcuts import reverse
 from django.contrib.auth.models import User
 
+from lists.models import List, ListItem
+
 
 class IndexCase(TestCase):
     def setUp(self) -> None:
@@ -11,5 +13,18 @@ class IndexCase(TestCase):
         client.login(username='test_user', password='test_password')
         self.index = client.get(reverse('lists-index'))
 
-    def test_http_ok(self) -> None:
+    def test_http_response(self) -> None:
         self.assertEqual(self.index.status_code, 200)
+
+class DisplayListCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = User.objects.create_user(username='test_user', password='test_password')
+        self.client.login(username='test_user', password='test_password')
+        self.test_list = List.objects.create(title='test_list', owner=self.user)
+
+    def test_http_response(self) -> None:
+        existing_list_response = self.client.get(reverse('list', args=[self.test_list.pk]))
+        nonexisting_list_response = self.client.get(reverse('list', args=[0]))
+        self.assertEqual(existing_list_response.status_code, 200)
+        self.assertEqual(nonexisting_list_response.status_code, 404)

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -1,0 +1,15 @@
+from django.test import TestCase
+from django.test import Client
+from django.shortcuts import reverse
+from django.contrib.auth.models import User
+
+
+class IndexCase(TestCase):
+    def setUp(self) -> None:
+        client = Client()
+        User.objects.create_user(username='test_user', password='test_password')
+        client.login(username='test_user', password='test_password')
+        self.index = client.get(reverse('lists-index'))
+
+    def test_http_ok(self) -> None:
+        self.assertEqual(self.index.status_code, 200)

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -28,3 +28,50 @@ class DisplayListCase(TestCase):
         nonexisting_list_response = self.client.get(reverse('list', args=[0]))
         self.assertEqual(existing_list_response.status_code, 200)
         self.assertEqual(nonexisting_list_response.status_code, 404)
+
+class ToggleItemCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = User.objects.create_user(username='test_user', password='test_password')
+        self.other_user = User.objects.create_user(username='some_other_guy', password='another_password')
+        self.client.login(username='test_user', password='test_password')
+        self.test_list = List.objects.create(title='test_list', owner=self.user)
+        self.other_guys_list = List.objects.create(title='I dunno what all this testing is about', owner=self.other_user)
+        self.our_item = ListItem.objects.create(name='This Item is Checked', completed=False)
+        self.our_item.list.add(self.test_list)
+        self.other_guys_item = ListItem.objects.create(name='This Item is Unchecked', completed=False)
+        self.other_guys_item.list.add(self.other_guys_list)
+
+    def test_permissions(self) -> None:
+        random_item_completed_before = self.other_guys_item.completed
+        checking_random_item = self.client.get(reverse('toggle-item',
+                                                       kwargs={
+                                                           'item': self.other_guys_item.pk,
+                                                           'list_pk': 1,
+                                                       }
+                                                       )) # Deliberately use bogus list_pk to make sure the function isn't using it for anything important
+        self.assertEqual(checking_random_item.status_code, 403)
+        self.assertEqual(random_item_completed_before, ListItem.objects.get(pk=self.other_guys_item.pk).completed)
+
+    def test_checking_and_unchecking(self) -> None:
+        our_item_completed_before = self.our_item.completed
+        checking_our_item = self.client.get(reverse('toggle-item',
+                                                    kwargs={
+                                                        'item': self.our_item.pk,
+                                                        'list_pk': 1,
+                                                    }))
+        self.assertNotEqual(ListItem.objects.get(pk=self.our_item.pk).completed, our_item_completed_before)
+        unchecking_our_item = self.client.get(reverse('toggle-item',
+                                                    kwargs={
+                                                        'item': self.our_item.pk,
+                                                        'list_pk': 1,
+                                                    }))
+        self.assertEqual(ListItem.objects.get(pk=self.our_item.pk).completed, our_item_completed_before)
+
+    def test_http_response(self) -> None:
+        checking_our_item = self.client.get(reverse('toggle-item',
+                                                    kwargs={
+                                                        'item': self.our_item.pk,
+                                                        'list_pk': 1,
+                                                    }))
+        self.assertEqual(checking_our_item.status_code, 302)

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -101,3 +101,27 @@ class ItemEditCase(TestCase):
                                               }
                                               )
         self.assertEqual(submitting_changes.status_code, 302)
+
+class ToggleListOnItemCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = User.objects.create_user(username='test_user', password='test_password')
+        self.client.login(username='test_user', password='test_password')
+        self.test_list = List.objects.create(title='test_list', owner=self.user)
+        self.test_other_list = List.objects.create(title='test_other_list', owner=self.user)
+        self.test_item = ListItem.objects.create(name='Test Item')
+        self.test_item.list.add(self.test_list)
+
+    def test_toggle(self) -> None:
+        self.client.post(reverse('toggle-list-on-item'), {
+            'item_pk': self.test_item.pk,
+            'list_pk': self.test_other_list.pk,
+            'current_list_pk': self.test_list.pk,
+        })
+        self.assertIn(self.test_other_list, self.test_item.list.all())
+        self.client.post(reverse('toggle-list-on-item'), {
+            'item_pk': self.test_item.pk,
+            'list_pk': self.test_other_list.pk,
+            'current_list_pk': self.test_list.pk,
+        })
+        self.assertNotIn(self.test_other_list, self.test_item.list.all())

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -75,3 +75,29 @@ class ToggleItemCase(TestCase):
                                                         'list_pk': 1,
                                                     }))
         self.assertEqual(checking_our_item.status_code, 302)
+
+class ItemEditCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = User.objects.create_user(username='test_user', password='test_password')
+        self.client.login(username='test_user', password='test_password')
+        self.test_list = List.objects.create(title='test_list', owner=self.user)
+        self.test_item = ListItem.objects.create(name='Test Item')
+        self.test_item.list.add(self.test_list)
+
+    def test_http_response(self) -> None:
+        viewing_interface = self.client.get(reverse('item-edit',
+                                                    kwargs={
+                                                        'item_pk': self.test_item.pk
+                                                    }))
+        self.assertEqual(viewing_interface.status_code, 200)
+        submitting_changes = self.client.post(reverse('item-edit',
+                                                      kwargs={
+                                                          'item_pk': self.test_item.pk
+                                                      }
+                                                      ),
+                                              {
+                                                  'name': 'Edited Test Item'
+                                              }
+                                              )
+        self.assertEqual(submitting_changes.status_code, 302)

--- a/lists/test_views.py
+++ b/lists/test_views.py
@@ -125,3 +125,23 @@ class ToggleListOnItemCase(TestCase):
             'current_list_pk': self.test_list.pk,
         })
         self.assertNotIn(self.test_other_list, self.test_item.list.all())
+
+
+class ToggleStarredCase(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+        self.user = User.objects.create_user(username='test_user', password='test_password')
+        self.client.login(username='test_user', password='test_password')
+        self.test_list = List.objects.create(title='test_list', owner=self.user)
+
+    def test_star_list(self):
+        response = self.client.get(reverse('toggle-starred', kwargs={
+            'list': self.test_list.pk
+        }))
+        self.assertEqual(response.context['star_button_fill'], '#ffd500')
+        self.assertIn(self.user, self.test_list.starred.all())
+        response = self.client.get(reverse('toggle-starred', kwargs={
+            'list': self.test_list.pk
+        }))
+        self.assertEqual(response.context['star_button_fill'], 'transparent')
+        self.assertNotIn(self.user, self.test_list.starred.all())

--- a/lists/urls.py
+++ b/lists/urls.py
@@ -4,8 +4,8 @@ from . import views
 urlpatterns = [
     path('', views.index, name='lists-index'),
     path('list/<int:list>', views.display_list, name='list'),
-    path('list/new', views.new_list, name='new-list'),
-    path('list/new/<int:parent>', views.new_list, name='new-sublist'),
+    path('list/edit', views.list_edit, name='list-edit'),
+    path('list/edit/<int:list_pk>', views.list_edit, name='list-edit'),
     path('item/edit', views.item_edit, name='item-edit'),
     path('item/edit/<int:item_pk>', views.item_edit, name='item-edit'),
     path('item/<int:item_pk>/details', views.item_details, name='item-details'),

--- a/lists/urls.py
+++ b/lists/urls.py
@@ -10,7 +10,6 @@ urlpatterns = [
     path('item/edit/<int:item_pk>', views.item_edit, name='item-edit'),
     path('item/<int:item_pk>/details', views.item_details, name='item-details'),
     path('item/toggle/<int:list_pk>/<int:item>', views.toggle_item, name='toggle-item'),
-    path('item/<int:current_list>/<int:item>/add/<int:list>', views.add_item_to_list, name='add-item-to-list'),
-    path('item/<int:current_list>/<int:item>/remove/<int:list>', views.remove_item_from_list, name='remove-item-from-list'),
+    path('item/toggle-list/', views.toggle_list_on_item, name='toggle-list-on-item'),
     path('list/star/<int:list>', views.toggle_starred, name='toggle-starred'),
 ]

--- a/lists/views.py
+++ b/lists/views.py
@@ -34,6 +34,8 @@ def display_list(request, list): #TODO: No folders, just parent lists. Any list 
 
 @login_required
 def toggle_item(request, item, list_pk):
+    if not item.list.all() & request.user.lists.all():
+        raise PermissionDenied()
     item = ListItem.objects.get(pk=item)
     item.completed = not item.completed
     item.checked_date = datetime.datetime.now()

--- a/lists/views.py
+++ b/lists/views.py
@@ -47,11 +47,6 @@ def toggle_item(request, item, list_pk):
          if (not item.completed) and item.parent.completed:
             toggle_item(request, item.parent.pk, list_pk)
     return HttpResponseRedirect(reverse('list', args=[list_pk]))
-    # return render(request, 'lists/list-item.html', {
-    #     'item': item,
-    #     'quick_access': request.user.starred.filter(),
-    #     'list_pk': list_pk,
-    # })
 
 @login_required
 def item_edit(request, item_pk=0):

--- a/lists/views.py
+++ b/lists/views.py
@@ -34,9 +34,9 @@ def display_list(request, list): #TODO: No folders, just parent lists. Any list 
 
 @login_required
 def toggle_item(request, item, list_pk):
+    item = ListItem.objects.get(pk=item)
     if not item.list.all() & request.user.lists.all():
         raise PermissionDenied()
-    item = ListItem.objects.get(pk=item)
     item.completed = not item.completed
     item.checked_date = datetime.datetime.now()
     item.save()


### PR DESCRIPTION
This is the result of about a week of refactoring views to make things easier to understand.
Mostly, this has been done to facilitate writing tests which won't have to change when all the views are refactored to classes.
I've shifted a lot of code out of views to form save methods, which are really nice when you actually use them. 
Most instances of values being passed to a view just so some template 3 layers deep can see it have been removed, in favor of pulling those values from html data attributes elsewhere in the page using hyperscript. This is more stable, and much, much less prone to breakage when making future changes. 